### PR TITLE
Modify reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # COM-Server
 
+**Note**: This is still in beta. If you want to help contributing/testing, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
+
 COM-Server is a Python library and a web server that hosts an API and interacts with serial or COM ports. The Python library provides a different way of sending and receiving data from the serial port using a thread, and it also gives a set of tools that simplifies the task of manipulating data to and from the port. Additionally, the server makes it easier for other processes to communicate with the serial port.
 
 The serial communication uses [pyserial](https://pyserial.readthedocs.io/en/latest/pyserial.html) as its back-end and the server uses [flask-restful](https://flask-restful.readthedocs.io/en/latest/quickstart.html) and [Flask](https://flask.palletsprojects.com/en/2.0.x/). Reading their documentations may help with developing with COM-Server.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # COM-Server
 
-**Note**: This is still in beta. If you want to help contributing/testing, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
+**Note**: This is still in beta. If you want to help contribute/test, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
 
 COM-Server is a Python library and a web server that hosts an API and interacts with serial or COM ports. The Python library provides a different way of sending and receiving data from the serial port using a thread, and it also gives a set of tools that simplifies the task of manipulating data to and from the port. Additionally, the server makes it easier for other processes to communicate with the serial port.
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -279,7 +279,7 @@ See [BaseConnection.\_\_init\_\_()](#baseconnection__init__)
 def __enter__()
 ```
 
-See [BaseConnection.\_\_enter\_\_()](#baseconnection__enter__)
+Same as [BaseConnection.\_\_enter\_\_()](#baseconnection__enter__) but returns a `Connection` object rather than a `BaseConnection` object.
 
 #### Connection.\_\_exit\_\_()
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -238,6 +238,32 @@ A property to determine if the connection object is currently connected to a ser
 This also can determine if the IO thread for this object
 is currently running or not.
 
+#### BaseConnection.timeout
+
+A property to determine the timeout of this object.
+
+Getter:
+
+- Gets the timeout of this object.
+
+Setter:
+
+- Sets the timeout of this object after checking if convertible to nonnegative float. 
+Then, sets the timeout to the same value on the `pyserial` object of this class.
+If the value is `float('inf')`, then sets the value of the `pyserial` object to None.
+
+#### BaseConnection.send_interval
+
+A property to determine the send interval of this object.
+
+Getter:
+
+- Gets the send interval of this object.
+
+Setter:
+
+- Sets the send interval of this object after checking if convertible to nonnegative float.
+
 ---
 
 ### com_server.Connection
@@ -324,6 +350,12 @@ See [BaseConnection.receive()](#baseconnectionreceive)
 #### Connection.connected
 
 See [BaseConnection.connected](#baseconnectionconnected)
+
+#### Connection.timeout
+See [BaseConnection.timeout](#baseconnectiontimeout)
+
+#### Connection.send_interval
+See [BaseConnection.send_interval](#baseconnectionsend_interval)
 
 #### Connection.conv_bytes_to_str()
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -54,7 +54,7 @@ If this does not happen, then the IO thread will still be running for an object 
 #### BaseConnection.\_\_init\_\_()
 
 ```py
-def __init__(baud, port, exception=True, timeout=1, queue_size=256, handle_disconnect=True, exit_on_disconnect=True, **kwargs)
+def __init__(baud, port, exception=True, timeout=1, queue_size=256, exit_on_disconnect=True, **kwargs)
 ```
 
 Initializes the Base Connection class. 
@@ -268,7 +268,7 @@ If this does not happen, then the IO thread will still be running for an object 
 #### Connection.\_\_init\_\_()
 
 ```py
-def __init__(baud, port, exception=True, timeout=1, queue_size=256, handle_disconnect=True, exit_on_disconnect=True, **kwargs)
+def __init__(baud, port, exception=True, timeout=1, queue_size=256, exit_on_disconnect=True, **kwargs)
 ```
 
 See [BaseConnection.\_\_init\_\_()](#baseconnection__init__)
@@ -552,24 +552,30 @@ def reconnect(port=None)
 Attempts to reconnect the serial port.
 
 This will change the `port` attribute then call `self.connect()`.
-Will raise `ConnectException` if already connected.
+Will raise `ConnectException` if already connected, regardless
+of if `exception` if True or not.
 
 Note that `reconnect()` can be used instead of `connect()`, but
 it will connect to the `port` parameter, not the `port` attribute
 when the class was initialized.
 
-Also note that this will most likely not work if `handle_disconnect`
-was initialized to False.
+This method will continuously try to connect to the port provided
+(unless `port` is None, in which case it will connect to the previous port)
+until it reaches given `timeout` seconds. If `timeout` is None, then it will
+continuously try to reconnect indefinitely.
 
 Parameters:
 
 - `port` (str, None) (optional): Program will reconnect to this port. 
 If None, then will reconnect to previous port. By default None.
+- `timeout` (float, None) (optional): Will try to reconnect for
+`timeout` seconds before returning. If None, then will try to reconnect
+indefinitely. By default None.
 
-May raise:
+Returns:
 
-- `com_server.ConnectException` if the user calls this function while it is already connected and `exception` is True.
-- `serial.serialutil.SerialException` if the port given in `__init__` does not exist.
+- True if able to reconnect
+- False if not able to reconnect within given timeout
 
 #### Connection.all_ports()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the COM-Server documentation.
 
-**Note**: This is still in beta. If you want to help contributing/testing, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
+**Note**: This is still in beta. If you want to help contribute/test, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
 
 COM-Server is a Python library and a web server that hosts an API and interacts with serial or COM ports. The Python library provides a different way of sending and receiving data from the serial port using a thread, and it also gives a set of tools that simplifies the task of manipulating data to and from the port. Additionally, the server makes it easier for other processes to communicate with the serial port.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Welcome to the COM-Server documentation.
 
+**Note**: This is still in beta. If you want to help contributing/testing, please read the [contributing page](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md).
+
 COM-Server is a Python library and a web server that hosts an API and interacts with serial or COM ports. The Python library provides a different way of sending and receiving data from the serial port using a thread, and it also gives a set of tools that simplifies the task of manipulating data to and from the port. Additionally, the server makes it easier for other processes to communicate with the serial port.
 
 The serial communication uses [pyserial](https://pyserial.readthedocs.io/en/latest/pyserial.html) as its back-end and the server uses [flask-restful](https://flask-restful.readthedocs.io/en/latest/quickstart.html) and [Flask](https://flask.palletsprojects.com/en/2.0.x/). Reading their documentations may help with developing with COM-Server.

--- a/src/com_server/api_builtins.py
+++ b/src/com_server/api_builtins.py
@@ -20,10 +20,11 @@ The above endpoints will not be available if the class is used.
 
 import typing as t
 
-from flask_restful import reqparse
 import flask_restful
+from flask_restful import reqparse
 
-from . import RestApiHandler, ConnectionResource, Connection, all_ports
+from . import Connection, ConnectionResource, RestApiHandler, all_ports
+
 
 class Builtins:
     """Contains implementations of endpoints that call methods of `Connection` object

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -12,7 +12,7 @@ import flask
 import flask_restful
 import waitress
 
-from . import base_connection, connection # for typing
+from . import base_connection, connection  # for typing
 
 
 class EndpointExistsException(Exception):

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -15,6 +15,7 @@ from types import TracebackType
 
 import serial
 
+
 class ConnectException(Exception):
     """
     Connecting/disconnecting errors

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -320,11 +320,12 @@ class BaseConnection:
         """A property to determine the timeout of this object.
 
         Getter:
-        - Gets the timeout of this object
+        - Gets the timeout of this object.
 
         Setter:
-        - Sets the timeout of this object after checking if convertible. 
+        - Sets the timeout of this object after checking if convertible to nonnegative float. 
         Then, sets the timeout to the same value on the `pyserial` object of this class.
+        If the value is `float('inf')`, then sets the value of the `pyserial` object to None.
         """
 
         return self._timeout
@@ -339,10 +340,10 @@ class BaseConnection:
         """A property to determine the send interval of this object.
         
         Getter:
-        - Gets the send interval of this object
+        - Gets the send interval of this object.
 
         Setter:
-        - Sets the send interval of this object after checking if convertible
+        - Sets the send interval of this object after checking if convertible to nonnegative float.
         """
 
         return self._send_interval

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -127,7 +127,7 @@ class Connection(base_connection.BaseConnection):
         - A list of tuples indicating the timestamp received and the bytes object received
         """
 
-        return self.rcv_queue
+        return self._rcv_queue
 
     def get_all_rcv_str(self, read_until: t.Union[str, None] = None, strip: bool = True) -> "list[tuple[float, str]]":
         """Returns entire receive queue as string.
@@ -148,7 +148,7 @@ class Connection(base_connection.BaseConnection):
         - A list of tuples indicating the timestamp received and the converted string from bytes 
         """
 
-        return [(ts, self.conv_bytes_to_str(rcv, read_until=read_until, strip=strip)) for ts, rcv in self.rcv_queue]
+        return [(ts, self.conv_bytes_to_str(rcv, read_until=read_until, strip=strip)) for ts, rcv in self._rcv_queue]
 
     def receive_str(self, num_before: int = 0, read_until: t.Union[str, None] = None, strip: bool = True) -> "t.Union[None, tuple[float, str]]":
         """Returns the most recent receive object as a string.
@@ -248,7 +248,7 @@ class Connection(base_connection.BaseConnection):
 
         # compares send time to receive time; return the first receive object where the send time < receive time
         while (r is None or r[0] < send_time):
-            if (time.time() - st > self.timeout):
+            if (time.time() - st > self._timeout):
                 # reached timeout
 
                 return None
@@ -340,21 +340,21 @@ class Connection(base_connection.BaseConnection):
             self.last_sent_outer = 0.0
 
         # check interval
-        if (time.time() - self.last_sent_outer < self.send_interval):
+        if (time.time() - self.last_sent_outer < self._send_interval):
             return False
         self.last_sent_outer = time.time()
 
         st_t = time.time()  # for timeout
 
         while (True):
-            if (time.time() - st_t > self.timeout):
+            if (time.time() - st_t > self._timeout):
                 # timeout reached
                 return False
 
             self.send(*args, check_type=check_type,
                       ending=ending, concatenate=concatenate)
 
-            if (time.time() - st_t > self.timeout):
+            if (time.time() - st_t > self._timeout):
                 # timeout reached
                 return False
 
@@ -434,8 +434,8 @@ class Connection(base_connection.BaseConnection):
         Raises exception or returns false if not.
         """
 
-        if (self.conn is None):
-            if (self.exception):
+        if (self._conn is None):
+            if (self._exception):
                 raise base_connection.ConnectException(
                     "No connection established")
 
@@ -455,7 +455,7 @@ class Connection(base_connection.BaseConnection):
 
         # wait for r to not be None or for received time to be greater than call time
         while (r is None or r[0] < _call_time):
-            if (time.time() - st_t > self.timeout):
+            if (time.time() - st_t > self._timeout):
                 # timeout reached
                 return None
 
@@ -476,7 +476,7 @@ class Connection(base_connection.BaseConnection):
 
         # wait for r to not be None or for received time to be greater than call time
         while (r is None or r[0] < _call_time):
-            if (time.time() - st_t > self.timeout):
+            if (time.time() - st_t > self._timeout):
                 # timeout reached
                 return None
 
@@ -497,7 +497,7 @@ class Connection(base_connection.BaseConnection):
 
         while (r is None or r[0] < timestamp or r[1] != response):
             # timestamp needs to be greater than start of method and response needs to match
-            if (time.time() - call_time > self.timeout):
+            if (time.time() - call_time > self._timeout):
                 # timeout reached
                 return False
 
@@ -518,7 +518,7 @@ class Connection(base_connection.BaseConnection):
 
         while (r is None or r[0] < timestamp or r[1] != response):
             # timestamp needs to be greater than start of method and response needs to match
-            if (time.time() - call_time > self.timeout):
+            if (time.time() - call_time > self._timeout):
                 # timeout reached
                 return False
 

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -37,6 +37,16 @@ class Connection(base_connection.BaseConnection):
     If this does not happen, then the IO thread will still be running for an object that has already been deleted.
     """
 
+    def __enter__(self) -> "Connection":
+        """
+        Same as `BaseConnection.__enter__()` but returns `Connection` object rather than a `BaseConnection` object.
+        """
+
+        if (not self.connected):
+            self.connect()
+        
+        return self
+
     def conv_bytes_to_str(self, rcv: bytes, read_until: t.Union[str, None] = None, strip: bool = True) -> t.Union[str, None]:
         """Convert bytes receive object to a string.
 
@@ -403,7 +413,7 @@ class Connection(base_connection.BaseConnection):
                 return True
             except SerialException as e:
                 # port not found
-                time.sleep(0.01)
+                time.sleep(0.01) # rest CPU
 
     def all_ports(self, **kwargs) -> t.Any:
         """Lists all available serial ports.

--- a/tests/test_all_ports.py
+++ b/tests/test_all_ports.py
@@ -9,7 +9,6 @@ import glob
 import sys
 import re
 
-from com_server.disconnect import _get_all_ports
 from com_server.tools import all_ports
 
 import pytest
@@ -35,15 +34,3 @@ def test_ports():
     ports = [a for a, _, _ in all_ports() if re.match(MATCH, a)]
 
     assert(len(ports) > 0)
-
-@pytest.mark.skipif(len(_usb+_acm) <= 0, reason="port not connected")
-def test_get_all():
-    """
-    Tests if `_get_all_ports()` disconnect is listing properly.
-    """
-
-    ports = _get_all_ports()
-
-    ports_all = [a for a in ports if re.match(MATCH, a)]
-
-    assert(len(ports_all) > 0)


### PR DESCRIPTION
Re-implemented the `Connection.reconnect()` method to wait until the serial port is reconnected rather than trying once and then exiting. It will break out after a certain amount of time. Additionally, added the `timeout` and `send_interval` properties so the user can read and change the timeout and send interval of the `Connection`/`BaseConnection` objects.