### PR TITLE
Add a thread lock for shared variables between main thread and IO thread (#32)

### DIFF
--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -150,7 +150,9 @@ def disconnect()
 
 Closes connection to the serial port.
 
-When called, calls `Serial.close()` then makes the connection `None`. If it is currently closed then just returns.
+When called, calls `Serial.close()` then makes the connection `None`. 
+If it is currently closed then just returns.
+Forces the IO thread to close.
 
 **NOTE**: This method should be called if the object will not be used anymore
 or before the object goes out of scope, as deleting the object without calling 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = com-server
-version = 0.0.1
+version = 0.0.2
 author = Jonathan Liu
 author_email = jonathanhliu21@gmail.com
 description = A simple Python library and a REST API server that interacts with COM ports 

--- a/src/com_server/__init__.py
+++ b/src/com_server/__init__.py
@@ -21,4 +21,4 @@ from .tools import all_ports
 
 from .api_builtins import Builtins
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/src/com_server/__main__.py
+++ b/src/com_server/__main__.py
@@ -10,6 +10,8 @@ Contains commands to run the COM server.
 import sys
 
 from docopt import docopt
+from flask import __version__ as f_v
+from serial import __version__ as s_v
 
 from . import __version__, runner
 
@@ -38,7 +40,14 @@ Options:
 """
 
 def _display_version() -> None:
-    print(f"COM_Server version: {__version__}")
+    _pyth_v = sys.version_info
+
+    p_o = f"COM_Server version: {__version__}\n" \
+        f"Flask version: {f_v}\n" \
+        f"Pyserial version: {s_v}\n" \
+        f"Python version: {_pyth_v.major}.{_pyth_v.minor}.{_pyth_v.micro}"
+
+    print(p_o)
     sys.exit()
 
 def main() -> None:

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -133,7 +133,7 @@ class BaseConnection:
 
         # this lock makes sure data from the receive queue
         # and send queue are written to and read safely
-        self.lock = threading.Lock()
+        self._lock = threading.Lock()
 
     def __repr__(self) -> str:
         """
@@ -280,7 +280,7 @@ class BaseConnection:
 
         # make sure nothing is reading/writing to the receive queue
         # while reading/assigning the variable
-        with self.lock:
+        with self._lock:
             if (len(self._to_send) < 65536):
                 # only append if limit has not been reached
                 self._to_send.append(send_data)
@@ -330,7 +330,7 @@ class BaseConnection:
         try:
             # make sure nothing is reading/writing to the receive queue
             # while reading/assigning the variable
-            with self.lock:
+            with self._lock:
                 self._last_rcv = self._rcv_queue[-1-num_before] # last received data
 
             return self._last_rcv
@@ -445,7 +445,7 @@ class BaseConnection:
             try:
                 # make sure other threads cannot read/write variables
                 # copy the variables to temporary ones so the locks don't block for so long
-                with self.lock:
+                with self._lock:
                     _rcv_queue = self._rcv_queue.copy()
                     _send_queue = self._to_send.copy()
 
@@ -472,7 +472,7 @@ class BaseConnection:
                     time.sleep(0.01)
                 
                 # make sure other threads cannot read/write variables
-                with self.lock:
+                with self._lock:
                     # copy the variables back
                     self._rcv_queue = _rcv_queue.copy()
                     self._to_send = _send_queue.copy()

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -5,7 +5,6 @@
 Contains implementation of Connection object.
 """
 
-import copy
 import json
 import os
 import signal

--- a/src/com_server/runner.py
+++ b/src/com_server/runner.py
@@ -9,11 +9,17 @@ from . import Connection, RestApiHandler, Builtins
 
 def run(baud: int, ser_port: int, env: str, host: str, port: str, timeout: int, send_interval: int):
     # init connection
-    conn = Connection(baud, ser_port, timeout=timeout, send_interval=send_interval) 
-    handler = RestApiHandler(conn)
-    Builtins(handler)
 
-    if (env == "dev"):
-        handler.run_dev(host=host, port=port)
-    else:
-        handler.run_prod(host=host, port=port)
+    print("Starting up connection with serial port...")
+    with Connection(baud, ser_port, timeout=timeout, send_interval=send_interval) as conn:
+        print("Connection with serial port established")
+
+        handler = RestApiHandler(conn)
+        Builtins(handler)
+
+        if (env == "dev"):
+            print("Launching Flask app...")
+            handler.run_dev(host=host, port=port)
+        else:
+            print("Launching Waitress server...")
+            handler.run_prod(host=host, port=port)


### PR DESCRIPTION
Added a `Lock` object that added a degree of thread safety with solves the bugs described in #32. 

Additionally, added more verbose output to the command line interface, including: 
- The versions of Flask, pyserial, and Python
- When the program is starting the connection with the serial port, starting the Flask app, or starting the Waitress server