### PR TITLE
Add custom io thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# 0.1 Development Release 1
+
+Previous version: 0.0.2
+
+## Changes from previous version:
+
+- Added the `SendQueue` and `ReceiveQueue` objects which allow the user to use  the send queues and receive queues without accidentally breaking the program
+    - Added tests for these objects
+- Added the ability for the user to define a custom IO thread with a connection object, the `ReceiveQueue`, and the `SendQueue` 
+- Added constants for the common baud rates:
+    - `NORMAL_BAUD_RATE`: 9600 bits/sec
+    - `FAST_BAUD_RATE`: 115200 bits/sec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,12 @@ I will change the merge branch if needed.
 
 **NOTE:** In the pull request, please specify the operating system and serial device (e.g. Arduino UNO, Arduino Mega, etc.) you tested COM-Server on.
 
+**NOTE**: To change the version, type in the below command, which should show the COM-Server version as `X.Y.N`. In `__init__`.py of the module and `setup.cfg`, change the `N`-value of the version to `N+1`. For example, if the version output is `0.0.2`, then change it to `0.0.3`. If it is `X.Y`, then change it to `X.Y.1`.
+
+```sh
+> com_server --version
+```
+
 
 ### Testing:
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -881,6 +881,218 @@ Parameters:
 
 ---
 
+### com_server.SendQueue
+
+The send queue object.
+
+This object is like a queue but cannot be iterated through. 
+It contains methods such as `front()` and `pop()`, just like
+the `queue` data structure in C++. However, objects cannot
+be added to it because objects should only be added through
+the `send()` method. 
+
+Makes sure the user only reads and pops from send queue
+and does not directly add or delete anything from the queue.
+
+#### SendQueue.\_\_init\_\_()
+
+```py
+def __init__(send_queue)
+```
+
+Constructor for the send queue object.
+
+Parameters:
+
+- `send_queue` (list): The list that will act as the send queue
+
+Returns:
+
+- Nothing
+
+#### SendQueue.front()
+
+```py
+def front()
+```
+
+Returns the first element of the send queue.
+
+Raises an `IndexError` if the length of the send queue is 0.
+
+Parameters:
+
+- None
+
+Returns:
+
+- The bytes object to send 
+
+#### SendQueue.pop()
+
+```py
+def pop()
+```
+
+Removes the first index from the queue.
+
+Raises an `IndexError` if the length of the send queue is 0.
+
+Parameters:
+
+- None
+
+Returns:
+
+- None
+
+#### SendQueue.copy()
+
+```py
+def copy()
+```
+
+Returns a shallow copy of the send queue list. 
+
+Using this to copy to a list may be dangerous, as
+altering elements in the list may alter the elements
+in the send queue itself. To prevent this, use the
+`deepcopy()` method.
+
+Parameters:
+
+- None
+
+Returns:
+
+- A shallow copy of the send queue
+
+#### com_server.deepcopy()
+
+```py
+def deepcopy()
+```
+
+Returns a deepcopy of the send queue list.
+
+By using this, you can modify the list without altering
+any elements of the actual send queue itself. However,
+it is a little more resource intensive.
+
+Parameters:
+
+- None
+
+Returns:
+
+- A deep copy of the send queue
+
+---
+
+### com_server.ReceiveQueue
+
+The ReceiveQueue object.
+
+This object is a queue, but the user can 
+only add bytes object(s) to it. 
+
+Makes sure the user does not directly add,
+delete, or modify the queue. 
+
+#### ReceiveQueue.\_\_init\_\_()
+
+```py
+def __init__(rcv_queue, queue_size)
+```
+
+Constructor for the send queue object.
+
+Parameters:
+
+- `rcv_queue` (list): The list that will act as the receive queue.
+- `queue_size` (int): The maximum size of the receive queue
+
+Returns:
+
+- Nothing 
+
+#### ReceiveQueue.pushitems()
+
+```py
+def pushitems(*args)
+```
+
+Adds a list of items to the receive queue.
+
+All items in `*args` must be a `bytes` object. A
+`TypeError` will be raised if not.
+
+If the size exceeds `queue_size` when adding, then
+it will pop the front of the queue. 
+
+A tuple (timestamp, bytes) will be added. The timestamp
+will be regenerated for each iteration of the for loop
+so they will be in order when binary searching.
+
+Parameters:
+
+- `*args`: The bytes objects to add
+
+Returns:
+
+- Nothing
+
+#### ReceiveQueue.copy()
+
+```py
+def copy()
+```
+
+Returns a shallow copy of the receive queue list. 
+
+The receive queue list will be a list of tuples:
+
+- (timestamp, bytes data)
+
+Using this to copy to a list may be dangerous, as
+altering elements in the list may alter the elements
+in the receive queue itself. To prevent this, use the
+`deepcopy()` method.
+
+Parameters:
+
+- None
+
+Returns:
+
+- A shallow copy of the receive queue
+
+#### ReceiveQueue.deepcopy()
+
+```py
+def deepcopy()
+```
+
+Returns a deepcopy of the receive queue.
+
+The receive queue list will be a list of tuples:
+
+- (timestamp, bytes data)
+
+By using this, you can modify the list without altering
+any elements of the actual send queue itself. However,
+it is a little more resource intensive.
+
+Parameters:
+
+- None
+
+Returns:
+
+- A deep copy of the receive queue
+
+---
+
 ## Constants
 
 ```py
@@ -894,6 +1106,13 @@ NO_SEND_INTERVAL = 0
 ```
 
 Use this if you do not want a send interval. Not recommended.
+
+```py
+NORMAL_BAUD_RATE = 9600
+FAST_BAUD_RATE = 115200
+```
+
+Standard baud rates that are commonly used.
 
 ```py
 NO_RCV_QUEUE = 1 

--- a/src/com_server/__init__.py
+++ b/src/com_server/__init__.py
@@ -17,7 +17,7 @@ from .api_server import ConnectionResource, RestApiHandler, EndpointExistsExcept
 from .constants import *
 from .base_connection import BaseConnection, ConnectException
 from .connection import Connection
-from .tools import all_ports
+from .tools import all_ports, SendQueue, ReceiveQueue
 
 from .api_builtins import Builtins
 

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -477,6 +477,7 @@ class BaseConnection:
                     self._to_send = _send_queue.copy()
 
                 time.sleep(0.01)  # rest CPU
+
             except (ConnectException, OSError, serial.SerialException):
                 # Disconnected, as all of the self.conn (pyserial) operations will raise
                 # an exception if the port is not connected.

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -600,6 +600,10 @@ class Connection(base_connection.BaseConnection):
                     _send_queue = self._to_send.copy()
 
                 self.cyc_func(self._conn, _rcv_queue, _send_queue)
+
+                if (len(_rcv_queue) > self._queue_size):
+                    # if greater than queue size, then pop first element
+                    _rcv_queue.pop(0)
                 
                 # make sure other threads cannot read/write variables
                 with self._lock:

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -434,6 +434,8 @@ class Connection(base_connection.BaseConnection):
     def custom_io_thread(self, func) -> t.Callable:
         """A decorator custom IO thread rather than using the default one.
 
+        It is recommended to read `pyserial`'s documentation before creating a custom IO thread.
+
         What the IO thread executes every 0.01 seconds will be referred to as a "cycle".
 
         Note that this method should be called **before** `connect()` is called, or

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -583,9 +583,9 @@ class Connection(base_connection.BaseConnection):
         # try to see if cycle function exists
         # if not, then use default cycle function
         try:
-            self.cyc_func
+            self._cyc_func
         except AttributeError:
-            self.cyc_func = self._default_cycle
+            self._cyc_func = self._default_cycle
 
         while (self._conn is not None):
             try:
@@ -595,12 +595,8 @@ class Connection(base_connection.BaseConnection):
                     _rcv_queue = tools.ReceiveQueue(self._rcv_queue.copy(), self._queue_size)
                     _send_queue = tools.SendQueue(self._to_send.copy())
 
-                self.cyc_func(self._conn, _rcv_queue, _send_queue)
+                self._cyc_func(self._conn, _rcv_queue, _send_queue)
 
-                if (len(_rcv_queue) > self._queue_size):
-                    # if greater than queue size, then pop first element
-                    _rcv_queue.pop(0)
-                
                 # make sure other threads cannot read/write variables
                 with self._lock:
                     # copy the variables back

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -430,6 +430,57 @@ class Connection(base_connection.BaseConnection):
         """
 
         return tools.all_ports(**kwargs)
+    
+    def custom_io_thread(self, func) -> t.Callable:
+        """A decorator custom IO thread rather than using the default one.
+
+        What the IO thread executes every 0.01 seconds will be referred to as a "cycle".
+
+        Note that this method should be called **before** `connect()` is called, or
+        else the thread will use the default cycle.
+
+        To see the default cycle, see the documentation of `BaseConnection`.
+
+        What the IO thread will do now is:
+
+        1. Check if anything is using (reading from/writing to) the variables
+        2. If not, copy the variables into a `SendQueue` and `ReceiveQueue` object.
+        3. Call the `custom_io_thread` function (if none, calls the default cycle)
+        4. Copy the results from the function back into the send queue and receive queue.
+        5. Rest for 0.01 seconds to rest the CPU
+
+        The cycle should be in a function that this decorator will be on top of.
+        The function should accept three parameters:
+        
+        - `conn` (a `serial.Serial` object)
+        - `rcv_queue` (a `ReceiveQueue` object; see more on how to use it in its documentation)
+        - `send_queue` (a `SendQueue` object; see more on how to use it in its documentation)
+
+        To enable autocompletion on your text editor, you can add type hinting:
+
+        ```py
+        from com_server import Connection, SendQueue, ReceiveQueue
+        from serial import Serial
+
+        conn = Connection(...)
+        
+        # some code
+
+        @conn.custom_io_thread
+        def custom_cycle(conn: Serial, rcv_queue: ReceiveQueue, send_queue: SendQueue):
+            # code here
+        
+        conn.connect() # call this AFTER custom_io_thread()
+
+        # more code
+        ``` 
+
+        The function below the decorator should not return anything.
+        """
+
+        self._cyc_func = func
+
+        return func
 
     def _check_connect(self) -> bool:
         """

--- a/src/com_server/constants.py
+++ b/src/com_server/constants.py
@@ -5,9 +5,15 @@
 A file containing constants for COM-Server.
 """
 
+# timeouts & send intervals
 NO_TIMEOUT = float("inf")
 NO_SEND_INTERVAL = 0
 
+# serial baud rates
+NORMAL_BAUD_RATE = 9600
+FAST_BAUD_RATE = 115200
+
+# receive queue
 NO_RCV_QUEUE = 1 # not 0 because the program would then disregard all incoming data
 RCV_QUEUE_SIZE_XSMALL = 32
 RCV_QUEUE_SIZE_SMALL = 128
@@ -15,5 +21,6 @@ RCV_QUEUE_SIZE_NORMAL = 256
 RCV_QUEUE_SIZE_LARGE = 512
 RCV_QUEUE_SIZE_XLARGE = 1024
 
+# server
 DEFAULT_HOST="0.0.0.0"
 DEFAULT_PORT=8080

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -12,6 +12,7 @@ import typing as t
 import serial
 import serial.tools.list_ports
 
+
 def all_ports(**kwargs) -> t.Any:
     """Gets all ports from serial interface.
 
@@ -20,6 +21,7 @@ def all_ports(**kwargs) -> t.Any:
     """
 
     return serial.tools.list_ports.comports(**kwargs)
+
 
 class SendQueue:
     """The send queue object
@@ -45,21 +47,21 @@ class SendQueue:
         """
 
         self._send_queue = send_queue
-    
+
     def __len__(self) -> int:
         """
         Returns length of send queue
         """
 
         return len(self._send_queue)
-    
+
     def __repr__(self) -> str:
         """
         String representation of queue
         """
 
         return f"SendQueue{self._send_queue}"
-    
+
     def front(self) -> bytes:
         """Returns the first element of the send queue.
 
@@ -73,7 +75,7 @@ class SendQueue:
         """
 
         return self._send_queue[0]
-    
+
     def pop(self) -> None:
         """Removes the first index from the queue.
 
@@ -81,13 +83,13 @@ class SendQueue:
 
         Parameters:
         - None
-        
+
         Returns:
         - None
         """
 
         self._send_queue.pop(0)
-    
+
     def copy(self) -> list:
         """Returns a shallow copy of the send queue list. 
 
@@ -102,7 +104,7 @@ class SendQueue:
         Returns:
         - A shallow copy of the send queue
         """
-    
+
         return self._send_queue.copy()
 
     def deepcopy(self) -> list:
@@ -121,9 +123,10 @@ class SendQueue:
 
         return copy.deepcopy(self._send_queue)
 
+
 class ReceiveQueue:
     """The ReceiveQueue object.
-    
+
     This object is a queue, but the user can 
     only add bytes object(s) to it. 
 
@@ -144,21 +147,21 @@ class ReceiveQueue:
 
         self._rcv_queue = rcv_queue
         self._queue_size = queue_size
-    
+
     def __len__(self) -> int:
         """
         Returns the length of the receive queue.
         """
 
         return len(self._rcv_queue)
-    
+
     def __repr__(self) -> str:
         """
         String representation of queue.
         """
 
         return f"ReceiveQueue{self._rcv_queue}"
-    
+
     def pushitems(self, *args) -> None:
         """Adds a list of items to the receive queue.
 
@@ -176,7 +179,7 @@ class ReceiveQueue:
         for obj in args:
             if (not isinstance(obj, bytes)):
                 raise TypeError("Every argument must be a bytes object")
-            
+
             # add timestamp, obj to queue
             self._rcv_queue.append((time.time(), obj))
 
@@ -201,7 +204,7 @@ class ReceiveQueue:
         Returns:
         - A shallow copy of the receive queue
         """
-    
+
         return self._rcv_queue.copy()
 
     def deepcopy(self) -> list:

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -5,6 +5,7 @@
 Provides a set of functions that could be generally useful.
 """
 
+import copy
 import typing as t
 
 import serial
@@ -18,3 +19,96 @@ def all_ports(**kwargs) -> t.Any:
     """
 
     return serial.tools.list_ports.comports(**kwargs)
+
+class SendQueue:
+    """The send queue object
+
+    This object is like a queue but cannot be iterated through. 
+    It contains methods such as `front()` and `pop()`, just like
+    the `queue` data structure in C++. However, objects cannot
+    be added to it because objects should only be added through
+    the `send()` method. 
+
+    Makes sure the user only reads and pops from send queue
+    and does not add or delete anything from the queue.
+    """
+
+    def __init__(self, send_queue: list) -> None:
+        """Constructor for send queue object.
+
+        Parameters:
+        - `send_queue` (list): The list that will act as the send queue 
+
+        Returns:
+        - Nothing
+        """
+
+        self._send_queue = send_queue
+    
+    def __len__(self) -> int:
+        """
+        Returns length of send queue
+        """
+
+        return len(self._send_queue)
+    
+    def front(self) -> bytes:
+        """Returns the first element of the send queue.
+
+        Raises an `IndexError` if the length of the send queue is 0.
+
+        Parameters:
+        - None
+
+        Returns:
+        - The bytes object to send 
+        """
+
+        return self._send_queue[0]
+    
+    def pop(self) -> None:
+        """Removes the first index from the queue.
+
+        Raises an `IndexError` if the length of the send queue is 0.
+
+        Parameters:
+        - None
+        
+        Returns:
+        - None
+        """
+
+        self._send_queue.pop(0)
+    
+    def copy(self) -> list:
+        """Returns a shallow copy of the send queue list. 
+
+        Using this to copy to a list may be dangerous, as
+        altering elements in the list may alter the elements
+        in the send queue itself. To prevent this, use the
+        `deepcopy()` method.
+
+        Parameters:
+        - None
+
+        Returns:
+        - A shallow copy of the list.
+        """
+    
+        return self._send_queue.copy()
+
+    def deepcopy(self) -> list:
+        """Returns a deepcopy of the list.
+
+        By using this, you can modify the list without altering
+        any elements of the actual send queue itself. However,
+        it is a little more resource intensive.
+
+        Parameters:
+        - None
+
+        Returns:
+        - A deep copy of the list
+        """
+
+        return copy.deepcopy(self._send_queue)

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -52,6 +52,13 @@ class SendQueue:
 
         return len(self._send_queue)
     
+    def __repr__(self) -> str:
+        """
+        String representation of queue
+        """
+
+        return f"SendQueue{self._send_queue}"
+    
     def front(self) -> bytes:
         """Returns the first element of the send queue.
 

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -6,6 +6,7 @@ Provides a set of functions that could be generally useful.
 """
 
 import copy
+import time
 import typing as t
 
 import serial
@@ -30,7 +31,7 @@ class SendQueue:
     the `send()` method. 
 
     Makes sure the user only reads and pops from send queue
-    and does not add or delete anything from the queue.
+    and does not directly add or delete anything from the queue.
     """
 
     def __init__(self, send_queue: list) -> None:
@@ -99,13 +100,13 @@ class SendQueue:
         - None
 
         Returns:
-        - A shallow copy of the list.
+        - A shallow copy of the send queue
         """
     
         return self._send_queue.copy()
 
     def deepcopy(self) -> list:
-        """Returns a deepcopy of the list.
+        """Returns a deepcopy of the send queue list.
 
         By using this, you can modify the list without altering
         any elements of the actual send queue itself. However,
@@ -115,7 +116,103 @@ class SendQueue:
         - None
 
         Returns:
-        - A deep copy of the list
+        - A deep copy of the send queue
         """
 
         return copy.deepcopy(self._send_queue)
+
+class ReceiveQueue:
+    """The ReceiveQueue object.
+    
+    This object is a queue, but the user can 
+    only add bytes object(s) to it. 
+
+    Makes sure the user does not directly add,
+    delete, or modify the queue. 
+    """
+
+    def __init__(self, rcv_queue: list, queue_size: int) -> None:
+        """Constructor for send queue object.
+
+        Parameters:
+        - `rcv_queue` (list): The list that will act as the receive queue.
+        - `queue_size` (int): The maximum size of the receive queue
+
+        Returns:
+        - Nothing 
+        """
+
+        self._rcv_queue = rcv_queue
+        self._queue_size = queue_size
+    
+    def __len__(self) -> int:
+        """
+        Returns the length of the receive queue.
+        """
+
+        return len(self._rcv_queue)
+    
+    def __repr__(self) -> str:
+        """
+        String representation of queue.
+        """
+
+        return f"ReceiveQueue{self._rcv_queue}"
+    
+    def additems(self, *args) -> None:
+        """Adds a list of items to the receive queue.
+
+        All items in `*args` must be a `bytes` object. A
+        `TypeError` will be raised if not.
+
+        If the size exceeds `queue_size` when adding, then
+        it will pop the front of the queue. 
+
+        A tuple (timestamp, bytes) will be added. The timestamp
+        will be regenerated for each iteration of the for loop
+        so they will be in order when binary searching.
+        """
+
+        for obj in args:
+            if (not isinstance(obj, bytes)):
+                raise TypeError("Every argument must be a bytes object")
+            
+            # add timestamp, obj to queue
+            self._rcv_queue.append((time.time(), obj))
+
+            if (len(self._rcv_queue) > self._queue_size):
+                # if greater than queue size, then pop first element
+                self._rcv_queue.pop(0)
+
+    def copy(self) -> list:
+        """Returns a shallow copy of the receive queue list. 
+
+        Using this to copy to a list may be dangerous, as
+        altering elements in the list may alter the elements
+        in the receive queue itself. To prevent this, use the
+        `deepcopy()` method.
+
+        Parameters:
+        - None
+
+        Returns:
+        - A shallow copy of the receive queue
+        """
+    
+        return self._rcv_queue.copy()
+
+    def deepcopy(self) -> list:
+        """Returns a deepcopy of the receive queue.
+
+        By using this, you can modify the list without altering
+        any elements of the actual send queue itself. However,
+        it is a little more resource intensive.
+
+        Parameters:
+        - None
+
+        Returns:
+        - A deep copy of the receive queue
+        """
+
+        return copy.deepcopy(self._rcv_queue)

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -159,7 +159,7 @@ class ReceiveQueue:
 
         return f"ReceiveQueue{self._rcv_queue}"
     
-    def additems(self, *args) -> None:
+    def pushitems(self, *args) -> None:
         """Adds a list of items to the receive queue.
 
         All items in `*args` must be a `bytes` object. A
@@ -187,6 +187,9 @@ class ReceiveQueue:
     def copy(self) -> list:
         """Returns a shallow copy of the receive queue list. 
 
+        The receive queue list will be a list of tuples:
+        - (timestamp, bytes data)
+
         Using this to copy to a list may be dangerous, as
         altering elements in the list may alter the elements
         in the receive queue itself. To prevent this, use the
@@ -203,6 +206,9 @@ class ReceiveQueue:
 
     def deepcopy(self) -> list:
         """Returns a deepcopy of the receive queue.
+
+        The receive queue list will be a list of tuples:
+        - (timestamp, bytes data)
 
         By using this, you can modify the list without altering
         any elements of the actual send queue itself. However,

--- a/src/com_server/tools.py
+++ b/src/com_server/tools.py
@@ -174,6 +174,12 @@ class ReceiveQueue:
         A tuple (timestamp, bytes) will be added. The timestamp
         will be regenerated for each iteration of the for loop
         so they will be in order when binary searching.
+
+        Parameters:
+        - `*args`: The bytes objects to add
+
+        Returns:
+        - Nothing
         """
 
         for obj in args:

--- a/tests/test_send_rcv.py
+++ b/tests/test_send_rcv.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Tests if send queue and receive queue are working properly.
+"""
+
+from com_server.tools import SendQueue
+
+SEND_LIST_TEST = [b"a\n", b"b\n", b"c\n", b"d\n"]
+
+def test_send_queue_initializes() -> None:
+    """
+    Tests if the object initializes
+    """
+
+    SendQueue(SEND_LIST_TEST)
+
+def test_send_queue_len_correct() -> None:
+    """
+    Tests if length of send queue is correct
+    """
+
+    sq = SendQueue(SEND_LIST_TEST)
+    assert len(sq) == len(SEND_LIST_TEST)
+
+def test_send_queue_repr_correct() -> None:
+    """
+    Tests that the send queue prints correctly
+    """
+
+    sq = SendQueue(SEND_LIST_TEST)
+    assert repr(sq) == f"SendQueue{SEND_LIST_TEST}"
+
+def test_front_pop() -> None:
+    """
+    Tests if front() and pop() are working correctly
+    """
+
+    sq = SendQueue(SEND_LIST_TEST.copy())
+    assert sq.front() == SEND_LIST_TEST[0]
+
+    sq.pop()
+
+    assert len(sq) == len(SEND_LIST_TEST)-1 
+
+def test_copy_deepcopy() -> None:
+    """
+    Tests if copy and deepcopy methods are working correctly.
+    """
+
+    sq = SendQueue(SEND_LIST_TEST.copy())
+    sq_cp1 = sq.copy()
+    sq_cp2 = sq.deepcopy()
+
+    assert sq_cp1 == SEND_LIST_TEST 
+    assert sq_cp2 == SEND_LIST_TEST

--- a/tests/test_send_rcv.py
+++ b/tests/test_send_rcv.py
@@ -5,9 +5,12 @@
 Tests if send queue and receive queue are working properly.
 """
 
-from com_server.tools import SendQueue
+import pytest
+from com_server.tools import SendQueue, ReceiveQueue
 
 SEND_LIST_TEST = [b"a\n", b"b\n", b"c\n", b"d\n"]
+RCV_LIST_TEST = [(0.0, b"a\n"), (0.1, b"b\n"), (0.1, b"c\n"), (0.1, b"d\n")]
+TEST_QUEUE_SIZE = 32
 
 def test_send_queue_initializes() -> None:
     """
@@ -32,7 +35,7 @@ def test_send_queue_repr_correct() -> None:
     sq = SendQueue(SEND_LIST_TEST)
     assert repr(sq) == f"SendQueue{SEND_LIST_TEST}"
 
-def test_front_pop() -> None:
+def test_send_queue_front_pop() -> None:
     """
     Tests if front() and pop() are working correctly
     """
@@ -44,7 +47,7 @@ def test_front_pop() -> None:
 
     assert len(sq) == len(SEND_LIST_TEST)-1 
 
-def test_copy_deepcopy() -> None:
+def test_send_queue_copy_deepcopy() -> None:
     """
     Tests if copy and deepcopy methods are working correctly.
     """
@@ -55,3 +58,59 @@ def test_copy_deepcopy() -> None:
 
     assert sq_cp1 == SEND_LIST_TEST 
     assert sq_cp2 == SEND_LIST_TEST
+
+def test_rcv_queue_initializes() -> None:
+    """
+    Test if rcv initializes
+    """
+
+    ReceiveQueue(RCV_LIST_TEST, TEST_QUEUE_SIZE)
+
+def test_rcv_queue_len_correct() -> None:
+    """
+    Test if __len__ is working
+    """
+
+    rq = ReceiveQueue(RCV_LIST_TEST, TEST_QUEUE_SIZE)
+    assert len(rq) == len(RCV_LIST_TEST)
+
+def test_rcv_queue_repr_correct() -> None:
+    """
+    Test if __repr__ is correct
+    """
+
+    rq = ReceiveQueue(RCV_LIST_TEST, TEST_QUEUE_SIZE)
+    assert repr(rq) == f"ReceiveQueue{RCV_LIST_TEST}"
+
+def test_rcv_queue_pushitems() -> None:
+    """
+    Tests that items push correctly and correct exceptions get thrown
+    """
+
+    rq = ReceiveQueue(RCV_LIST_TEST, TEST_QUEUE_SIZE)
+    rq.pushitems(*[b"abc"]*135)
+
+    def _is_rcv_queue_sorted(rcv_q: list) -> bool:
+        for i in range(1, len(rcv_q)):
+            if (rcv_q[i][0] < rcv_q[i-1][0]):
+                return False 
+        
+        return True
+    
+    assert _is_rcv_queue_sorted(rq._rcv_queue)
+    assert len(rq) == TEST_QUEUE_SIZE
+
+    with pytest.raises(TypeError):
+        rq.pushitems(1, 2, 3)
+
+def test_rcv_queue_copy_deepcopy() -> None:
+    """
+    Tests if copy and deepcopy methods are working correctly.
+    """
+
+    sq = ReceiveQueue(RCV_LIST_TEST.copy(), TEST_QUEUE_SIZE)
+    sq_cp1 = sq.copy()
+    sq_cp2 = sq.deepcopy()
+
+    assert sq_cp1 == RCV_LIST_TEST 
+    assert sq_cp2 == RCV_LIST_TEST


### PR DESCRIPTION
Added a changelog, which reads:

# 0.1 Development Release 1

Previous version: 0.0.2

## Changes from previous version:

- Added the `SendQueue` and `ReceiveQueue` objects which allow the user to use  the send queues and receive queues without accidentally breaking the program
    - Added tests for these objects
- Added the ability for the user to define a custom IO thread with a connection object, the `ReceiveQueue`, and the `SendQueue` 
- Added constants for the common baud rates:
    - `NORMAL_BAUD_RATE`: 9600 bits/sec
    - `FAST_BAUD_RATE`: 115200 bits/sec
