### PR TITLE
Add arguments for port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ Previous version: 0.0.*
 - Added constants for the common baud rates:
     - `NORMAL_BAUD_RATE`: 9600 bits/sec
     - `FAST_BAUD_RATE`: 115200 bits/sec
+- Added the ability to initialize with multiple ports, addressing #39
 - Added a changelog to keep track of changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,5 @@ Previous version: 0.0.*
 - Added constants for the common baud rates:
     - `NORMAL_BAUD_RATE`: 9600 bits/sec
     - `FAST_BAUD_RATE`: 115200 bits/sec
-- Added the ability to initialize with multiple ports, addressing #39
+- Added the ability to initialize with multiple ports, addressing [#39](https://github.com/jonyboi396825/COM-Server/issues/39)
 - Added a changelog to keep track of changes

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -140,7 +140,7 @@ Returns: None
 May raise:
 
 - `com_server.ConnectException` if the user calls this function while it is already connected and `exception` is True.
-- `serial.serialutil.SerialException` if the port given in `__init__` does not exist.
+- `serial.serialutil.SerialException` if the port(s) given in `__init__` does not exist.
 - `EnvironmentError` if `exit_on_disconnect` is True and the user is on Windows (_not tested_).
 
 #### BaseConnection.disconnect()

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -66,18 +66,19 @@ If this does not happen, then the IO thread will still be running for an object 
 #### BaseConnection.\_\_init\_\_()
 
 ```py
-def __init__(baud, port, exception=True, timeout=1, queue_size=256, exit_on_disconnect=True, **kwargs)
+def __init__(baud, port, *ports, exception=True, timeout=1, queue_size=256, exit_on_disconnect=True, **kwargs)
 ```
 
 Initializes the Base Connection class. 
 
-`baud`, `port`, `timeout`, and `kwargs` will be passed to pyserial.  
+`baud`, `port` (or a port within `ports`), `timeout`, and `kwargs` will be passed to pyserial.  
 For more information, see [here](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial).
 
 Parameters:
 
 - `baud` (int): The baud rate of the serial connection 
 - `port` (str): The serial port
+- `*ports`: Alternative serial ports to choose if the first port does not work. The program will try the serial ports in order of arguments and will use the first one that works.
 - `timeout` (float) (optional): How long the program should wait, in seconds, for serial data before exiting. By default 1.
 - `exception` (bool) (optional): Raise an exception when there is a user error in the methods rather than just returning. By default True.
 - `send_interval` (int) (optional): Indicates how much time, in seconds, the program should wait before sending another message. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = com-server
-version = 0.0.2
+version = 0.1b0
 author = Jonathan Liu
 author_email = jonathanhliu21@gmail.com
 description = A simple Python library and a REST API server that interacts with COM ports 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = com-server
-version = 0.0.1
+version = 0.0.2
 author = Jonathan Liu
 author_email = jonathanhliu21@gmail.com
 description = A simple Python library and a REST API server that interacts with COM ports 

--- a/src/com_server/__init__.py
+++ b/src/com_server/__init__.py
@@ -21,4 +21,4 @@ from .tools import all_ports
 
 from .api_builtins import Builtins
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/src/com_server/__init__.py
+++ b/src/com_server/__init__.py
@@ -21,4 +21,4 @@ from .tools import all_ports
 
 from .api_builtins import Builtins
 
-__version__ = "0.0.2"
+__version__ = "0.1b0"

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -88,7 +88,7 @@ class BaseConnection:
     ) -> None:
         """Initializes the Base Connection class. 
 
-        `baud`, `port`, `timeout`, and `kwargs` will be passed to pyserial.  
+        `baud`, `port` (or a port within `ports`), `timeout`, and `kwargs` will be passed to pyserial.  
         For more information, see [here](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial).
 
         Parameters:

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -499,7 +499,7 @@ class BaseConnection:
 
                     # delete the first element of send queue attribute for every object that was sent
                     # as those elements were the ones that were sent
-                    for i in range(_num_to_send):
+                    for _ in range(_num_to_send):
                         self._to_send.pop(0)
 
                 time.sleep(0.01)  # rest CPU

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -193,7 +193,7 @@ class BaseConnection:
         _all_avail_ports = [port for port, _, _ in tools.all_ports()]
 
         # actual used port
-        _used_port = None
+        _used_port = "No port found"
         
         for port in _all_ports:
             if (port in _all_avail_ports):


### PR DESCRIPTION
Address #39 and allow multiple ports to be added, making the program choose the first one that works.

The ports will be added through the `*ports` optional argument(s) and the program will choose the first argument that works. If none of them work, then it will raise a `SerialException`, indicating that there is no port named "No port found."