### PR TITLE
Fix tests for mac and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Serial ports:
 - Arduino UNO
 - Arduino Nano
 
+## Recommended use
+COM-Server is **not** meant to be used like a normal JSON API, even though it uses Flask and Flask-restful. If there are many different devices accessing the endpoints at the same time, data will be backed up, since the serial communication is relatively slow and things cannot be sent to the serial device at the same time. 
+
+The server is recommended to be used like a socket, and it should be used as a way for another process (should be only one; COM-Server has no implemented synchronization) on one computer (could be the same computer or another one on the same network) to communicate with the serial port via `pyserial` and this Python program. 
+ 
+
 ## Installation
 
 **NOTE**: COM-Server only works on Python >= 3.6.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -272,3 +272,10 @@ conn.disconnect()
 
 Again, note that the endpoints listed above cannot be used.
 
+## Using the endpoints
+
+Assuming that you're using the `com_server` command to run or `has_register_recall` is False when initializing your `RestApiHandler`, then you need to access the `/register` and `/recall` to ensure to the program that there is only one IP/device connecting (see [Recommended Use](/#recommended-use)). 
+
+When you are beginning to use the serial port, send a GET request to `/register`, and when you are finished, send a GET request to `/recall`. There are no arguments needed.
+
+There is a built-in endpoint for almost every of the methods in `Connection`, in addition to the `send` and `receive` methods of `BaseConnection`. See the [Server API](/server/server-api) for more information on how to use them. Note that if you send a request to the `/send` endpoint or a send-based endpoint (an endpoint that sends any data to the serial port) too rapidly (under the time specified in `send_interval`), it will respond with a 502 error. 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -791,7 +791,7 @@ Some arguments include:
 
 - `host`: The host of the server. Ex: `localhost`, `0.0.0.0`, `127.0.0.1`, etc.
 - `port`: The port to host it on. Ex: `5000` (default), `8000`, `8080`, etc.
-- `debug`: If the app should be used in debug mode. 
+- `debug`: If the app should be used in debug mode. Note that this may break some things because of reloads.
 
 May raise:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,22 +29,19 @@ Serial ports:
 - Arduino Nano
 
 It is likely that this library will not work for non-USB ports. 
- 
-## Links
-- Documentation: [https://com-server.readthedocs.io/en/latest/](https://com-server.readthedocs.io/en/latest/)
-- Source code: [https://github.com/jonyboi396825/COM-Server](https://github.com/jonyboi396825/COM-Server)
-- Issue tracker: [https://github.com/jonyboi396825/COM-Server/issues](https://github.com/jonyboi396825/COM-Server/issues)
-- Contributing: [https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md)
 
 ## Contents
 
 - [Home](/)
+    - [Recommended Use](/#recommended-use)
     - [Links](/#links)
     - [Installation](/#installation)
     - [Quickstart](/#quickstart)
     - [License](/#license)
 - [Getting Started](guide/getting-started)
     - [Creating a Connection Class](guide/getting-started/#creating-a-connection-class)
+    - [Creating a RestApiHandler Class](guide/getting-started/#creating-a-restapihandler-class)
+    - [Using the endpoints](guide/getting-started/#using-the-endpoints)
 - [Library API](guide/library-api)
     - [Functions](guide/library-api/#functions)
         - [com_server.all_ports()](guide/library-api/#com_serverall_ports)
@@ -59,6 +56,20 @@ It is likely that this library will not work for non-USB ports.
         - [com_server.EndpointExistsException](guide/library-api/#com_serverendpointexistsexception)
 - [Command line interface](guide/cli/)
 - [Server API](server/server-api)
+    - [Endpoints from RestApiHandler](server/server-api/#endpoints-from-restapihandler)
+    - [Endpoints from Builtins](server/server-api/#endpoints-from-builtins)
+    - [Escape characters](server/server-api/#escape-characters)
+
+## Recommended use
+COM-Server is **not** meant to be used like a normal JSON API, even though it uses Flask and Flask-restful. If there are many different devices accessing the endpoints at the same time, data will be backed up, since the serial communication is relatively slow and things cannot be sent to the serial device at the same time. 
+
+The server is recommended to be used like a socket, and it should be used as a way for another process (should be only one; COM-Server has no implemented synchronization) on one computer (could be the same computer or another one on the same network) to communicate with the serial port via `pyserial` and this Python program. 
+ 
+## Links
+- Documentation: [https://com-server.readthedocs.io/en/latest/](https://com-server.readthedocs.io/en/latest/)
+- Source code: [https://github.com/jonyboi396825/COM-Server](https://github.com/jonyboi396825/COM-Server)
+- Issue tracker: [https://github.com/jonyboi396825/COM-Server/issues](https://github.com/jonyboi396825/COM-Server/issues)
+- Contributing: [https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md](https://github.com/jonyboi396825/COM-Server/blob/master/CONTRIBUTING.md)
 
 ## Installation
 

--- a/docs/server/server-api.md
+++ b/docs/server/server-api.md
@@ -317,7 +317,7 @@ $ curl -X POST -d "data=hello" -d $'ending=\n' <url>
 
 ### JSON
 
-When sending JSON data to then endpoints, use `\\n`, `\\r`, etc. for escape characters. That is, add an additional backslash to the beginning of the character.
+Escape characters do not yet work with JSON.
 
 ### Adding more programs
 

--- a/docs/server/server-api.md
+++ b/docs/server/server-api.md
@@ -298,3 +298,27 @@ Response:
     - `{"message": "OK", ports = [["...", "...", "..."], "..."]}` where "ports"
     is a list of lists of size 3, each one indicating the port, description, and
     technical description
+
+## Escape characters
+
+When including escape characters (newlines, carriage returns, etc.) in a post request to one of the endpoints, the request might not interpret the character. For example, in some cases, if you send `ending="\n"` to the `/send` endpoint (other endpoints have this issue too; we're just using `/send` as an example), the server may interpret it as `\\n` (a backslash followed by `n`), rather than an actual newline. Below contains a list of ways to solve this for different programs:
+
+### Python requests library
+
+The Python requests library works by default if you put a normal newline character `\n` (or any other escape character) in the string. 
+
+### cURL
+
+If you are using `zsh` or `bash`, then you can use the `$''` syntax to include escape characters. For example, sending data to `/send` with cURL can look like:
+
+```bash
+$ curl -X POST -d "data=hello" -d $'ending=\n' <url>
+```
+
+### JSON
+
+When sending JSON data to then endpoints, use `\\n`, `\\r`, etc. for escape characters. That is, add an additional backslash to the beginning of the character.
+
+### Adding more programs
+
+If you want to add more programs to this list, feel free to submit a [pull request](https://github.com/jonyboi396825/COM-Server/pulls). If something does not work or you see something wrong, please submit an [issue](https://github.com/jonyboi396825/COM-Server/issues) under the category "Documentation."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = com-server
-version = 0.0.4
+version = 0.0.5
 author = Jonathan Liu
 author_email = jonathanhliu21@gmail.com
 description = A simple Python library and a REST API server that interacts with COM ports 

--- a/src/com_server/__init__.py
+++ b/src/com_server/__init__.py
@@ -21,4 +21,4 @@ from .tools import all_ports
 
 from .api_builtins import Builtins
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/tests/test_all_ports.py
+++ b/tests/test_all_ports.py
@@ -21,8 +21,8 @@ if (sys.platform.startswith("linux")):
 elif (sys.platform.startswith("darwin")):
     # mac; use cu.*, not tty.*
     _usb = glob.glob("/dev/cu.usbserial*")
-    _acm = []
-    MATCH = "/dev/cu.usbserial.*"
+    _acm = glob.glob("/dev/cu.usbmodem*")
+    MATCH = "/dev/cu.usb(serial|modem).*"
 elif (sys.platform.startswith("win")):
     # windows
     _usb = [f"COM{i+1}" for i in range(256)]

--- a/tests/test_server_running.py
+++ b/tests/test_server_running.py
@@ -191,8 +191,8 @@ if (sys.platform.startswith("linux")):
 elif (sys.platform.startswith("darwin")):
     # mac; use cu.*, not tty.*
     _usb = glob.glob("/dev/cu.usbserial*")
-    _acm = []
-    MATCH = "/dev/cu.usbserial.*"
+    _acm = glob.glob("/dev/cu.usbmodem*")
+    MATCH = "/dev/cu.usb(serial|modem).*"
 elif (sys.platform.startswith("win")):
     # windows
     _usb = [f"COM{i+1}" for i in range(256)]


### PR DESCRIPTION
Fix the `all_ports` tests for macs so they pass instead of being skipped for ports named `cu.usbmodem*`. 