### PR TITLE
Add CORS

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -11,18 +11,20 @@ with the serial port in an development environment or a
 production environment.
 
 Usage:
-    com_server (-p | --serport) <serport> (-b | --baud) <baud> run [--env=<env>] [--host=<host>] [--port=<port>] [--s-int=<s-int>] [--to=<to>]
+    com_server (-p | --serport) <serport> (-b | --baud) <baud> run [--env=<env>] [--host=<host>] [--port=<port>] [--s-int=<s-int>] [--to=<to>] [--cors]
     com_server -h | --help
     com_server --version
 
 Options:
-    -p, --serport    The serial port to connect to. For MacOS, use the "cu.*" port rather than the "tty.*" port.
-    -b, --baud       The baud rate of the serial connection.
-    --env=<env>      Development or production environment. Value must be 'dev' or 'prod'. [default: dev].
-    --host=<host>    The name of the host server (optional) [default: 0.0.0.0].
-    --port=<port>    The port of the host server (optional) [default: 8080].
-    --s-int=<s-int>  How long, in seconds, the program should wait between sending to serial port [default: 1].
-    --to=<to>        How long, in seconds, the program should wait before exiting when performing time-consuming tasks [default: 1].
+    -p, --serport   The serial port to connect to. For MacOS, use the "cu.*" port rather than the "tty.*" port.
+    -b, --baud      The baud rate of the serial connection.
+    --env=<env>     Development or production environment. Value must be 'dev' or 'prod'. [default: dev].
+    --host=<host>   The name of the host server (optional) [default: 0.0.0.0].
+    --port=<port>   The port of the host server (optional) [default: 8080].
+    --s-int=<s-int>  
+                    How long, in seconds, the program should wait between sending to serial port [default: 1].
+    --to=<to>       How long, in seconds, the program should wait before exiting when performing time-consuming tasks [default: 1].
+    --cors          If set, then the program will add cross origin resource sharing.
 
     -h, --help      Show help.
     --version       Show version.

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -764,7 +764,7 @@ call `/register` to use the serial port
 #### RestApiHandler.\_\_init\_\_()
 
 ```py
-def __init__(conn, has_register_recall, **kwargs)
+def __init__(conn, has_register_recall, add_cors, **kwargs)
 ```
 
 Constructor for class
@@ -776,6 +776,7 @@ Parameters:
 so the user will not have to use them in order to access the other endpoints of the API.
 That is, visiting endpoints will not respond with a 400 status code even if `/register` was not
 accessed. By default True. 
+- `add_cors` (bool): If True, then the Flask app will have [cross origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enabled. By default False.
 - `**kwargs`, will be passed to `flask_restful.Api()`. See [here](https://flask-restful.readthedocs.io/en/latest/api.html#id1) for more info.
 
 May raise:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ setuptools>=58.5.3
 wheel>=0.37.0
 pyserial>=3.5
 flask_restful>=0.3.9
+flask_cors>=3.0.10
 docopt>=0.6.2
 waitress>=2.0.0
 requests>=2.26.0

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         "wheel>=0.37.0",
         "pyserial>=3.5",
         "flask_restful>=0.3.9",
+        "flask-cors>=3.0.10"
         "docopt>=0.6.2",
         "waitress>=2.0.0"
     ]

--- a/src/com_server/__main__.py
+++ b/src/com_server/__main__.py
@@ -22,18 +22,20 @@ with the serial port in an development environment or a
 production environment.
 
 Usage:
-    com_server (-p | --serport) <serport> (-b | --baud) <baud> run [--env=<env>] [--host=<host>] [--port=<port>] [--s-int=<s-int>] [--to=<to>]
+    com_server (-p | --serport) <serport> (-b | --baud) <baud> run [--env=<env>] [--host=<host>] [--port=<port>] [--s-int=<s-int>] [--to=<to>] [--cors]
     com_server -h | --help
     com_server --version
 
 Options:
-    -p, --serport    The serial port to connect to. For MacOS, use the "cu.*" port rather than the "tty.*" port.
-    -b, --baud       The baud rate of the serial connection.
-    --env=<env>      Development or production environment. Value must be 'dev' or 'prod'. [default: dev].
-    --host=<host>    The name of the host server (optional) [default: 0.0.0.0].
-    --port=<port>    The port of the host server (optional) [default: 8080].
-    --s-int=<s-int>  How long, in seconds, the program should wait between sending to serial port [default: 1].
-    --to=<to>        How long, in seconds, the program should wait before exiting when performing time-consuming tasks [default: 1].
+    -p, --serport   The serial port to connect to. For MacOS, use the "cu.*" port rather than the "tty.*" port.
+    -b, --baud      The baud rate of the serial connection.
+    --env=<env>     Development or production environment. Value must be 'dev' or 'prod'. [default: dev].
+    --host=<host>   The name of the host server (optional) [default: 0.0.0.0].
+    --port=<port>   The port of the host server (optional) [default: 8080].
+    --s-int=<s-int>  
+                    How long, in seconds, the program should wait between sending to serial port [default: 1].
+    --to=<to>       How long, in seconds, the program should wait before exiting when performing time-consuming tasks [default: 1].
+    --cors          If set, then the program will add cross origin resource sharing.
 
     -h, --help      Show help.
     --version       Show version.
@@ -67,12 +69,13 @@ def main() -> None:
         port = args["--port"].strip()
         timeout = args["--to"].strip()
         send_interval = args["--s-int"].strip()
+        add_cors = args["--cors"]
 
         if (env not in ('dev', 'prod')):
             print("Value of <env> must be \"dev\" or \"prod\".")
             sys.exit(1)
         
-        runner.run(baud, serport, env, host, port, timeout, send_interval)
+        runner.run(baud, serport, env, host, port, timeout, send_interval, add_cors)
 
         print("Exited")
 

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -76,6 +76,7 @@ class RestApiHandler:
         so the user will not have to use them in order to access the other endpoints of the API.
         That is, visiting endpoints will not respond with a 400 status code even if `/register` was not
         accessed. By default True. 
+        - `add_cors` (bool): If True, then the Flask app will have [cross origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enabled. By default False.
         - `**kwargs`, will be passed to `flask_restful.Api()`. See [here](https://flask-restful.readthedocs.io/en/latest/api.html#id1) for more info.
         """
 

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -9,6 +9,7 @@ the web API for the Serial port.
 import typing as t
 
 import flask
+import flask_cors
 import flask_restful
 import waitress
 

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -61,7 +61,12 @@ class RestApiHandler:
     call `/register` to use the serial port
     """
 
-    def __init__(self, conn: t.Union[t.Type[base_connection.BaseConnection], t.Type[connection.Connection]], has_register_recall: bool = True, **kwargs) -> None:
+    def __init__(
+        self,
+        conn: t.Union[t.Type[base_connection.BaseConnection], t.Type[connection.Connection]],
+        has_register_recall: bool = True,
+        **kwargs
+    ) -> None:
         """Constructor for class
 
         Parameters:

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -68,7 +68,7 @@ class RestApiHandler:
         add_cors: bool = False,
         **kwargs
     ) -> None:
-        """Constructor for class
+        """Constructor for classf
 
         Parameters:
         - `conn` (`Connection`): The `Connection` object the API is going to be associated with.  

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -65,6 +65,7 @@ class RestApiHandler:
         self,
         conn: t.Union[t.Type[base_connection.BaseConnection], t.Type[connection.Connection]],
         has_register_recall: bool = True,
+        add_cors: bool = False,
         **kwargs
     ) -> None:
         """Constructor for class

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -9,9 +9,9 @@ the web API for the Serial port.
 import typing as t
 
 import flask
-import flask_cors
 import flask_restful
 import waitress
+from flask_cors import CORS
 
 from . import base_connection, connection  # for typing
 
@@ -89,7 +89,7 @@ class RestApiHandler:
         self._api = flask_restful.Api(self._app, **kwargs)
 
         if (add_cors):
-            flask_cors.CORS(self._app)
+            CORS(self._app)
 
         # other
         self._all_endpoints = [] # list of all endpoints in tuple (endpoint str, resource class)

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -87,6 +87,9 @@ class RestApiHandler:
         self._app = flask.Flask(__name__)
         self._api = flask_restful.Api(self._app, **kwargs)
 
+        if (add_cors):
+            flask_cors.CORS(self._app)
+
         # other
         self._all_endpoints = [] # list of all endpoints in tuple (endpoint str, resource class)
         self._registered = None # keeps track of who is registered; None if not registered

--- a/src/com_server/api_server.py
+++ b/src/com_server/api_server.py
@@ -68,7 +68,7 @@ class RestApiHandler:
         add_cors: bool = False,
         **kwargs
     ) -> None:
-        """Constructor for classf
+        """Constructor for class
 
         Parameters:
         - `conn` (`Connection`): The `Connection` object the API is going to be associated with.  

--- a/src/com_server/runner.py
+++ b/src/com_server/runner.py
@@ -7,14 +7,14 @@ Contains implementation of `run` argument from the CLI.
 
 from . import Connection, RestApiHandler, Builtins
 
-def run(baud: int, ser_port: int, env: str, host: str, port: str, timeout: int, send_interval: int):
+def run(baud: int, ser_port: int, env: str, host: str, port: str, timeout: int, send_interval: int, cors: bool) -> None:
     # init connection
 
     print("Starting up connection with serial port...")
     with Connection(baud, ser_port, timeout=timeout, send_interval=send_interval) as conn:
         print("Connection with serial port established")
 
-        handler = RestApiHandler(conn)
+        handler = RestApiHandler(conn, add_cors=cors)
         Builtins(handler)
 
         if (env == "dev"):


### PR DESCRIPTION
Add the option to add cross origin resource sharing to the Flask app when initializing the `RestApiHandler`, addressing #45. 