### PR TITLE
Remove function needed for `add_endpoints` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-# 0.1 Development Release 1
+# 0.1 Beta Release 0
 
 Previous version: 0.0.*
+
+## IMPORTANT: BREAKING changes from previous version:
+
+- Changed the way the `RestApiHandler.add_endpoint` decorator works:
+    - Instead of having the decorator above a function which returns a nested class, the decorator will instead go directly above the class that extends `ConnectionResource`. To use the connection, use `self.conn` in the methods.
 
 ## Changes from previous version:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jonyboi396825/COM-Server/Run%20Pytest%20(Push%20to%20master))
 [![Documentation Status](https://readthedocs.org/projects/com-server/badge/?version=latest)](https://com-server.readthedocs.io/en/latest/?badge=latest)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jonyboi396825/COM-Server/Upload%20Python%20Package?label=PyPI%20upload)
 
 COM-Server is a Python library and a local web server that hosts an API locally and interacts with serial or COM ports. The Python library provides a different way of sending and receiving data from the serial port using a thread, and it also gives a set of tools that simplifies the task of manipulating data to and from the port. Additionally, the server makes it easier for other processes to communicate with the serial port.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -246,25 +246,21 @@ There is no need to assign a variable to `Builtins` as all it does is add the en
 
 To add custom endpoints, use the `add_endpoints` decorator above a function with a nested class in it. The nested class should extend `ConnectionResource` and have functions similar to the classes of `flask_restful`. See [here](https://flask-restful.readthedocs.io/en/latest/quickstart.html#a-minimal-api) for more info. The function needs to have a `conn` parameter indicating the connection object and lastly needs to return the nested class.
 
-The example below adds an endpoint at `/hello_world` and returns `{"Hello": "world"}` when there is a GET request.
+The example below adds an endpoint at `/hello_world`, sends "`Hello world\n`" to the serial port, then returns `{"Hello": "world"}` when there is a GET request.
 
 ```py
-import flask
-import flask_restful
 from com_server import Connection, RestApiHandler, Builtins, ConnectionResource
 
 conn = Connection(port="/dev/ttyUSB0", baud=115200)
 handler = RestApiHandler(conn)
 Builtins(handler)
 
-@handler.add_endpoints("/hello_world")
-def hello_world(conn):
-    class HelloWorldEndpoint(ConnectionResource):
-        def get(self):
-            return {"Hello", "world"}
+@handler.add_endpoint("/hello_world")
+class HelloWorldEndpoint(ConnectionResource):
+    def get(self):
+        self.conn.send("Hello", "world", ending='\n')
+        return {"Hello": "world"}
     
-    return HelloWorldEndpoint
-
 handler.run_dev(host="0.0.0.0", port=8080)
 
 conn.disconnect()

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -791,13 +791,12 @@ def add_endpoint(endpoint)
 
 Decorator that adds an endpoint
 
-This decorator needs to go above a function which
-contains a nested class that extends `ConnectionResource`.
-The function needs a parameter indicating the serial connection.
-The function needs to return that nested class.
-The class should contain implementations of request
-methods such as `get()`, `post()`, etc. similar to the 
-`Resource` class from `flask_restful`.
+This decorator should go above a class that
+extends `ConnectionResource`. The class should 
+contain implementations of request methods such as
+`get()`, `post()`, etc. similar to the `Resource`
+class from `flask_restful`. To use the connection
+object, use the `self.conn` attribute.
 
 For more information, see the `flask_restful` [documentation](https://flask-restful.readthedocs.io).
 
@@ -815,11 +814,6 @@ Parameters:
 - `endpoint`: The endpoint to the resource. Cannot repeat.
 `/register` and `/recall` cannot be used, even if
 `has_register_recall` is False
-
-May raise:
-
-- `com_server.EndpointExistsException`: If an endpoint already exists
-- `TypeError` if the function does not return a class that extends `com_server.ConnectionResource`
 
 #### RestApiHandler.add_resource()
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -815,6 +815,12 @@ Parameters:
 `/register` and `/recall` cannot be used, even if
 `has_register_recall` is False
 
+May raise:
+
+- `com_server.EndpointExistsException`: If an endpoint already exists
+- `TypeError` if the class does not extend `com_server.ConnectionResource`
+
+
 #### RestApiHandler.add_resource()
 
 ```py

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,25 +14,18 @@ def test_endpointexistsexception() -> None:
     handler = com_server.RestApiHandler(conn)
 
     @handler.add_endpoint("/test1")
-    def test1(conn):
-        class Test1(com_server.ConnectionResource):
-            pass
-
-        return Test1
+    class Test1(com_server.ConnectionResource):
+        pass
 
     # should raise EndpointExistsException
     with pytest.raises(com_server.api_server.EndpointExistsException) as e:
         @handler.add_endpoint("/test1")
-        def test2(conn):
-            class Test1(com_server.ConnectionResource):
-                pass
-
-            return Test1
+        class Test1(com_server.ConnectionResource):
+            pass
 
     ex = e.value
     assert isinstance(ex, com_server.api_server.EndpointExistsException)
     
-
 def test_subclass_type_exception() -> None:
     """
     Tests if exception is being thrown if subclass extends wrong type
@@ -44,11 +37,8 @@ def test_subclass_type_exception() -> None:
     # should raise TypeError
     with pytest.raises(TypeError) as e:
         @handler.add_endpoint("/test2")
-        def test2(conn):
-            class Test1(Resource):
-                pass
-
-            return Test1
+        class Test1(Resource):
+            pass
     
     ex = e.value
     assert isinstance(ex, TypeError)
@@ -62,20 +52,14 @@ def test_duplicate_class_no_exception() -> None:
     handler = com_server.RestApiHandler(conn)
 
     @handler.add_endpoint("/hello_world")
-    def hello_world_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world"}
-    
-        return Hello_World_
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world"} 
     
     @handler.add_endpoint("/hello_world_2")
-    def hello_world_2_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world2"}
-        
-        return Hello_World_
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world2"}    
     
     for e, r in handler._all_endpoints: 
         handler._api.add_resource(r, e)
@@ -91,20 +75,15 @@ def test_duplicate_func_name_no_exception() -> None:
     handler = com_server.RestApiHandler(conn)
 
     @handler.add_endpoint("/hello_world")
-    def hello_world_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world"}
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world"}
     
-        return Hello_World_
     
     @handler.add_endpoint("/hello_world_2")
-    def hello_world_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world2"}
-        
-        return Hello_World_
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world2"}    
     
     for e, r in handler._all_endpoints: 
         handler._api.add_resource(r, e)
@@ -118,20 +97,13 @@ if (__name__ == "__main__"):
     handler = com_server.RestApiHandler(conn)
 
     @handler.add_endpoint("/hello_world")
-    def hello_world_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world"}
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world"} 
     
-        return Hello_World_
-    
-    @handler.add_endpoint("/hello_world_2")
-    def hello_world_2_test(conn):
-        class Hello_World_(com_server.ConnectionResource):
-            def get(self):
-                return {"hello": "world2"}
-        
-        return Hello_World_
+    class Hello_World_(com_server.ConnectionResource):
+        def get(self):
+            return {"hello": "world2"}    
     
     handler.run_dev(host='0.0.0.0', port=8080)
     


### PR DESCRIPTION
Make `RestApiHandler.add_endpoints` decorator go directly above a class, and add a `Connection` attribute to the `ConnectionResource` instead of passing the connection in as a parameter. Makes code cleaner.