### PR TITLE
Add io delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Previous version: 0.1b0
 
 - Fixed [#63](https://github.com/jonyboi396825/COM-Server/issues/63) by making 404 handling default behavior
 - Made IO thread in `BaseConnection` abstract
-- Added new endpoint `/connection_state`, getting some properties of the `Connection` object
+- Added new endpoint `/connection_state`, getting some properties of the `Connection` object, addressing [#60](https://github.com/jonyboi396825/COM-Server/issues/60)
+- Added option to remove 0.01 second delay at end of IO thread, addressing [#68](https://github.com/jonyboi396825/COM-Server/issues/68)
+- `exception` in `BaseConnection` and `Connection` objects is now **DEPRECATED**
 
 # 0.1 Beta Release 0
 

--- a/docs/guide/custom-io-thread.md
+++ b/docs/guide/custom-io-thread.md
@@ -42,7 +42,7 @@ This is how the program will execute the IO thread now:
 1. Since the receive queue and send queue are shared between the main thread and IO thread, the IO thread will wait for the thread lock to be freed (i.e. for those variables to not be used by the main thread), then copy the shared receive queue and send queue (which are native Python lists) to temporary `ReceiveQueue` and `SendQueue` objects. Then, it will release the thread lock.
 2. The IO thread will execute the function declared by the user from the `custom_io_thread` decorator, passing in the three arguments. The temporary `ReceiveQueue` and `SendQueue` objects should be altered afterwords.
 3. Again, the thread will wait for the send queue and receive queue to stop being used. When they are, it will copy the temporary `ReceiveQueue` back to the original receive queue. Then, it will pop all the elements that were used in the temporary `SendQueue` in the original send queue. It does this by comparing the initial size of the temporary `SendQueue` before running the function with the final size of the queue after running the function. The number of elements removed from the queue is the difference between the final size and initial size.
-4. Sleep for 0.01 seconds to rest the CPU
+4. Sleep for 0.01 seconds to rest the CPU if `rest_cpu` is True (which it is by default)
 
 The IO thread will continue doing these 4 things until the program is stopped or until the device disconnects.
 

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -57,7 +57,7 @@ Parameters:
 - `port` (str): The serial port
 - `*ports`: Alternative serial ports to choose if the first port does not work. The program will try the serial ports in order of arguments and will use the first one that works.
 - `timeout` (float) (optional): How long the program should wait, in seconds, for serial data before exiting. By default 1.
-- `exception` (bool) (optional): Raise an exception when there is a user error in the methods rather than just returning. By default True.
+- `exception` (bool) (optional): (**DEPRECATED**) Raise an exception when there is a user error in the methods rather than just returning. By default True.
 - `send_interval` (float) (optional): Indicates how much time, in seconds, the program should wait before sending another message. 
 Note that this does NOT mean that it will be able to send every `send_interval` seconds. It means that the `send()` method will 
 exit if the interval has not reached `send_interval` seconds. NOT recommended to set to small values. By default 1.

--- a/docs/guide/library-api.md
+++ b/docs/guide/library-api.md
@@ -43,7 +43,7 @@ If this does not happen, then the IO thread will still be running for an object 
 #### BaseConnection.\_\_init\_\_()
 
 ```py
-def __init__(baud, port, *ports, exception=True, timeout=1, queue_size=256, exit_on_disconnect=True, **kwargs)
+def __init__(baud, port, *ports, exception=True, timeout=1, send_interval=1, queue_size=256, exit_on_disconnect=True, rest_cpu=True, **kwargs)
 ```
 
 Initializes the Base Connection class. 
@@ -58,11 +58,13 @@ Parameters:
 - `*ports`: Alternative serial ports to choose if the first port does not work. The program will try the serial ports in order of arguments and will use the first one that works.
 - `timeout` (float) (optional): How long the program should wait, in seconds, for serial data before exiting. By default 1.
 - `exception` (bool) (optional): Raise an exception when there is a user error in the methods rather than just returning. By default True.
-- `send_interval` (int) (optional): Indicates how much time, in seconds, the program should wait before sending another message. 
+- `send_interval` (float) (optional): Indicates how much time, in seconds, the program should wait before sending another message. 
 Note that this does NOT mean that it will be able to send every `send_interval` seconds. It means that the `send()` method will 
 exit if the interval has not reached `send_interval` seconds. NOT recommended to set to small values. By default 1.
 - `queue_size` (int) (optional): The number of previous data that was received that the program should keep. Must be nonnegative. By default 256.
 - `exit_on_disconnect` (bool) (optional): If True, sends `SIGTERM` signal to the main thread if the serial port is disconnected. Does NOT work on Windows. By default False.
+- `rest_cpu` (bool) (optional): If True, will add 0.01 second delay to end of IO thread. Otherwise, removes those delays but will result in increased CPU usage.
+Not recommended to set False with the default IO thread. By default True.
 - `kwargs`: Will be passed to pyserial.
 
 Returns: nothing

--- a/src/com_server/api_builtins.py
+++ b/src/com_server/api_builtins.py
@@ -38,7 +38,7 @@ class Builtins:
         - `/send/get_first` (POST): Responds with the first string response from the serial port after sending data, with data and parameters in request; equivalent to `Connection.get_first_response(is_bytes=False, ...)`
         - `/get/wait` (POST): Waits until connection receives string data given in request; different response for success and failure; equivalent to `Connection.wait_for_response(...)`
         - `/send/get` (POST): Continues sending something until connection receives data given in request; different response for success and failure; equivalent to `Connection.send_for_response(...)`
-        - `/connection_state` (GET): Get the properties of the `Connection` object: connected, timeout, send_interval, conn_obj, available, port 
+        - `/connection_state` (GET): Get the properties of the `Connection` object: connected, timeout, send_interval, conn_obj, available, port
         - `/connected` (GET): Indicates if the serial port is currently connected or not
         - `/list_ports` (GET): Lists all available Serial ports
 
@@ -625,12 +625,12 @@ class Builtins:
                 return {"message": "OK"}
 
         return _SendResponse
-    
+
     def _connection_state(_self) -> t.Type[Connection]:
         """
         Responds with an object of the properties of the connection state.
 
-        - `timeout` (float): The timeout of the object, or how much time it will try doing 
+        - `timeout` (float): The timeout of the object, or how much time it will try doing
         something, such as sending data, before breaking out of the program
         - `send_interval` (float): The time the program will wait before allowing something
         to be sent to the serial port again
@@ -642,7 +642,7 @@ class Builtins:
 
         Arguments:
             None
-        
+
         Response:
 
         - `200 OK`:
@@ -657,10 +657,10 @@ class Builtins:
                         "timeout": self.conn.timeout,
                         "send_interval": self.conn.send_interval,
                         "available": self.conn.available,
-                        "port": self.conn.port
-                    }
+                        "port": self.conn.port,
+                    },
                 }
-            
+
         return _ConnectionState
 
     def _connected(_self) -> t.Type[Connection]:

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -78,7 +78,7 @@ class BaseConnection(abc.ABC):
             - `port` (str): The serial port
             - `*ports`: Alternative serial ports to choose if the first port does not work. The program will try the serial ports in order of arguments and will use the first one that works.
             - `timeout` (float) (optional): How long the program should wait, in seconds, for serial data before exiting. By default 1.
-            - `exception` (bool) (optional): Raise an exception when there is a user error in the methods rather than just returning. By default True.
+            - `exception` (bool) (optional): (**DEPRECATED**) Raise an exception when there is a user error in the methods rather than just returning. By default True.
             - `send_interval` (float) (optional): Indicates how much time, in seconds, the program should wait before sending another message.
             Note that this does NOT mean that it will be able to send every `send_interval` seconds. It means that the `send()` method will
             exit if the interval has not reached `send_interval` seconds. NOT recommended to set to small values. By default 1.

--- a/src/com_server/base_connection.py
+++ b/src/com_server/base_connection.py
@@ -62,9 +62,10 @@ class BaseConnection(abc.ABC):
         *ports,
         exception: bool = True,
         timeout: float = 1,
-        send_interval: int = 1,
+        send_interval: float = 1,
         queue_size: int = constants.RCV_QUEUE_SIZE_NORMAL,
         exit_on_disconnect: bool = False,
+        rest_cpu: bool = True,
         **kwargs,
     ) -> None:
         """Initializes the Base Connection class.
@@ -78,11 +79,13 @@ class BaseConnection(abc.ABC):
             - `*ports`: Alternative serial ports to choose if the first port does not work. The program will try the serial ports in order of arguments and will use the first one that works.
             - `timeout` (float) (optional): How long the program should wait, in seconds, for serial data before exiting. By default 1.
             - `exception` (bool) (optional): Raise an exception when there is a user error in the methods rather than just returning. By default True.
-            - `send_interval` (int) (optional): Indicates how much time, in seconds, the program should wait before sending another message.
+            - `send_interval` (float) (optional): Indicates how much time, in seconds, the program should wait before sending another message.
             Note that this does NOT mean that it will be able to send every `send_interval` seconds. It means that the `send()` method will
             exit if the interval has not reached `send_interval` seconds. NOT recommended to set to small values. By default 1.
             - `queue_size` (int) (optional): The number of previous data that was received that the program should keep. Must be nonnegative. By default 256.
             - `exit_on_disconnect` (bool) (optional): If True, sends `SIGTERM` signal to the main thread if the serial port is disconnected. Does NOT work on Windows. By default False.
+            - `rest_cpu` (bool) (optional): If True, will add 0.01 second delay to end of IO thread. Otherwise, removes those delays but will result in increased CPU usage.
+            Not recommended to set to False with the default IO thread. By default True.
             - `kwargs`: Will be passed to pyserial.
 
         Returns: nothing
@@ -99,6 +102,7 @@ class BaseConnection(abc.ABC):
         self._queue_size = abs(int(queue_size))  # make sure positive
         self._send_interval = abs(float(send_interval))  # make sure positive
         self._exit_on_disconnect = exit_on_disconnect
+        self._rest_cpu = rest_cpu
 
         if os.name == "nt" and self._exit_on_disconnect:
             raise EnvironmentError("exit_on_fail is not supported on Windows")

--- a/src/com_server/connection.py
+++ b/src/com_server/connection.py
@@ -724,7 +724,8 @@ class Connection(base_connection.BaseConnection):
             for _ in range(_num_to_send_i - _num_to_send_f):
                 self._to_send.pop(0)
 
-        time.sleep(0.01)  # rest CPU
+        if self._rest_cpu:
+            time.sleep(0.01)  # rest CPU
 
     def _io_thread(self) -> None:
         """Thread that interacts with the serial port.


### PR DESCRIPTION
Add option to remove 0.01s delay at end of IO thread and also deprecated `exception` attribute.